### PR TITLE
refactor: load_articles 함수 구조 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 venv/
+__pycache__/
+*.py[cod]
+.env

--- a/src/process_news.py
+++ b/src/process_news.py
@@ -3,15 +3,12 @@ import json
 from datetime import datetime
 from collect_news import collect_news, save_news
 from sentiment.finbert_sentiment import analyze_sentiment_finbert
+from summary.gpt_summary import summarize_article
 
-# GPT 요약 모듈은 추후 연결
-def dummy_summary(text):
-    return "This is a placeholder summary."
+def get_article_path(ticker, date_str):
+    return f"data/news/{ticker}_{date_str}.json"
 
-def load_articles(ticker):
-    date_str = datetime.now().strftime('%Y-%m-%d')
-    path = f"data/news/{ticker}_{date_str}.json"
-
+def load_articles(path):
     if os.path.exists(path):
         with open(path, "r", encoding="utf-8") as f:
             print(f"📁 기존 뉴스 불러오기: {path}")
@@ -20,31 +17,31 @@ def load_articles(ticker):
 
 def process_news(ticker, name):
     date_str = datetime.now().strftime('%Y-%m-%d')
-    path = f"data/news/{ticker}_{date_str}.json"
+    path = get_article_path(ticker, date_str)
 
-    # 1. 뉴스 수집 (이미 있으면 스킵)
-    articles = load_articles(ticker)
+    # 1. 뉴스 수집 (없을 경우에만)
+    articles = load_articles(path)
     if not articles:
         print(f"📡 뉴스 수집 시작: {ticker} ({name})")
         articles = collect_news(ticker, name)
         save_news(ticker, articles)
 
-    # 2. 감성 분석 추가 (없을 경우만)
+    # 2. 감성 분석 수행 (없는 경우에만)
     for article in articles:
         if "sentiment_label" not in article:
             label, score = analyze_sentiment_finbert(article.get("full_content", ""))
             article["sentiment_label"] = label
             article["sentiment_score"] = score
 
-    # 3. 요약 (없을 경우만)
+    # 3. GPT 요약 수행 (없는 경우에만)
     for article in articles:
         if "summary" not in article:
-            article["summary"] = dummy_summary(article.get("full_content", ""))
+            article["summary"] = summarize_article(article.get("full_content", ""))
 
     # 4. 저장
     save_news(ticker, articles)
 
 if __name__ == "__main__":
-    # 테스트용 실행
+    # 테스트 실행용
     process_news("TSLA", "Tesla")
     # 실제 사용 시에는 collect_all_from_json() 함수를 호출하여 전체 기업에 대해 처리


### PR DESCRIPTION
## 📌 개요
- 기존 load_articles() 함수 구조를 개선(외부에서 path를 직접 전달할 수 있도록 변경)하여 뉴스 데이터 로딩의 유연성과 테스트 확장성을 높임

## ✨ 주요 변경 사항
#### 기존 코드
```
def load_articles(ticker):
    date_str = datetime.now().strftime('%Y-%m-%d')
    path = f"data/news/{ticker}_{date_str}.json"
```
- load_articles() 내부에서 path를 생성하는 방식
-> 날짜나 경로를 바꾸기 어렵고 고정되어 있어 유연성이 떨어짐

#### 변경 코드
```
def load_articles(path):
    if os.path.exists(path):
        ...
```
- path를 인자로 직접 전달함으로써 호출하는 쪽에서 유연하게 경로 제어 가능

## 🔍 작업 상세 내용
- path를 받도록 load_articles() 구성하고 별도로 path 생성을 관리하는 get_article_path() 추가