### PR TITLE
chore: 문서 임베딩 / 인덱스 생성 함수 머지

### DIFF
--- a/src/search/embed_document.py
+++ b/src/search/embed_document.py
@@ -1,0 +1,58 @@
+#단일 문서 임베딩을 위한 코드
+import os
+import json
+from tqdm import tqdm
+import faiss
+from sentence_transformers import SentenceTransformer
+
+# 1. 금융 특화 SBERT 모델 로딩
+MODEL_NAME = "baconnier/Finance2_embedding_small_en-V1.5"
+model = SentenceTransformer(MODEL_NAME,
+                            use_auth_token=True)
+
+# 2. 데이터 경로 설정
+data_dir = "data/news"
+
+# 3. 문서와 메타데이터 수집
+documents = []
+metadatas = []
+for filename in os.listdir(data_dir):
+    if not filename.endswith(".json"):
+        continue
+    with open(os.path.join(data_dir, filename), "r", encoding="utf-8") as f:
+        articles = json.load(f)
+    for art in articles:
+        txt = art.get("full_content", "").strip()
+        if len(txt) < 30:
+            continue
+        documents.append(txt)
+        metadatas.append({
+            "title": art.get("title"),
+            "source": art.get("source", {}).get("name"),
+            "publishedAt": art.get("publishedAt"),
+            "filename": filename
+        })
+
+print(f"▶ 임베딩할 문서 수: {len(documents)}")
+
+# 4. 배치 임베딩 수행
+# convert_to_numpy=True 로 넘파이 배열 반환, show_progress_bar=True 로 진행 표시
+embeddings = model.encode(
+    documents,
+    batch_size=32,
+    show_progress_bar=True,
+    convert_to_numpy=True
+)
+
+# 5. FAISS 인덱스 생성 및 저장
+dim = embeddings.shape[1]
+index = faiss.IndexFlatL2(dim)
+index.add(embeddings)
+
+os.makedirs("vectorstore", exist_ok=True)
+faiss.write_index(index, "vectorstore/financial_news_index.faiss")
+
+with open("vectorstore/financial_news_metadata.json", "w", encoding="utf-8") as f:
+    json.dump(metadatas, f, ensure_ascii=False, indent=2)
+
+print("✅ 금융 특화 FAISS 인덱스 및 메타데이터 저장 완료")

--- a/src/search/index_news.py
+++ b/src/search/index_news.py
@@ -1,0 +1,82 @@
+#뉴스 코퍼스 전체를 한 번에 읽어서 임베딩하고 FAISS 인덱스를 생성해 파일로 저장하는 배치 스크립트트
+
+import os
+import json
+import faiss
+from sentence_transformers import SentenceTransformer
+
+
+def main():
+    # 1) 금융 특화 SBERT 모델 로드
+    MODEL_NAME = "baconnier/Finance2_embedding_small_en-V1.5"
+    model = SentenceTransformer(MODEL_NAME)
+
+    # 2) 프로젝트 루트 기준 뉴스 데이터 경로
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    data_dir = os.path.join(project_root, "data", "news")
+
+    if not os.path.isdir(data_dir):
+        raise FileNotFoundError(f"뉴스 데이터 디렉토리를 찾을 수 없습니다: {data_dir}")
+
+    # 3) 뉴스 문서와 메타데이터 수집
+    documents = []
+    metadatas = []
+    for fn in os.listdir(data_dir):
+        if not fn.endswith(".json"): 
+            continue
+        path = os.path.join(data_dir, fn)
+        with open(path, "r", encoding="utf-8") as f:
+            articles = json.load(f)
+        for art in articles:
+            raw = art.get("full_content")
+            if not raw:
+                continue
+            text = raw.strip()
+            if len(text) < 30:
+                continue
+            documents.append(text)
+            metadatas.append({
+                "title": art.get("title"),
+                "source": art.get("source", {}).get("name"),
+                "publishedAt": art.get("publishedAt"),
+                "filename": fn
+            })
+
+    print(f"▶ 임베딩 문서 수: {len(documents)}")
+
+    # 4) 배치 임베딩 수행
+    embeddings = model.encode(
+        documents,
+        batch_size=32,
+        show_progress_bar=True,
+        convert_to_numpy=True
+    )
+
+    # 5) FAISS 인덱스 생성
+    dim = embeddings.shape[1]
+    index = faiss.IndexFlatL2(dim)
+    index.add(embeddings)
+
+    # 6) 인덱스 및 메타데이터 저장 경로
+    vs_dir = os.path.join(project_root, "vectorstore")
+    os.makedirs(vs_dir, exist_ok=True)
+    index_path = os.path.join(vs_dir, "financial_news_index.faiss")
+    meta_path = os.path.join(vs_dir, "financial_news_metadata.json")
+
+    # 7) 파일로 저장
+    faiss.write_index(index, index_path)
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(metadatas, f, ensure_ascii=False, indent=2)
+
+    print(f"✅ FAISS 인덱스 저장 완료: {index_path}")
+
+
+if __name__ == "__main__":
+    main()
+
+# (venv) PS C:\Users\toast\genai> python src/search/index_news.py
+# C:\Users\toast\genai\venv\lib\site-packages\sentence_transformers\SentenceTransformer.py:196: FutureWarning: The `use_auth_token` argument is deprecated and will be removed in v4 of SentenceTransformers.
+#   warnings.warn(
+# ▶ 임베딩 문서 수: 332
+# Batches: 100%|██████████| 11/11 [01:40<00:00,  9.18s/it]
+# ✅ FAISS 인덱스 저장 완료: C:\Users\toast\genai\vectorstore\financial_news_index.faiss


### PR DESCRIPTION
## 📌 개요
-단일 문서 임베딩 생성 기능, 뉴스 기사 전체 배치 인덱싱 기능을 추가해 RAG 기반 검색·유사도 시스템의 초기 데이터 파이프라인 완성

## ✨ 주요 변경 사항
####embed_document.py
- 단일 문서(뉴스 한 건) 임베딩 생성 함수(embed_single_document) 구현

####index_news.py
- 전체 뉴스 파일을 불러와 FAISS 인덱스를 생성하고 메타데이터(JSON) 저장 기능 구현


## 🧪 테스트

```
import os
import json
import faiss
from sentence_transformers import SentenceTransformer

def main():
    # 1) 모델 로드
    MODEL_NAME = "baconnier/Finance2_embedding_small_en-V1.5"
    model = SentenceTransformer(MODEL_NAME)

    # 2) FAISS 인덱스 로드 
    index_path = os.path.join("vectorstore", "financial_news_index.faiss")
    metadata_path = os.path.join("vectorstore", "financial_news_metadata.json")

    assert os.path.exists(index_path), f"Index file not found: {index_path}"
    assert os.path.exists(metadata_path), f"Metadata file not found: {metadata_path}"

    index = faiss.read_index(index_path)

    # 3) 메타데이터 로드
    with open(metadata_path, "r", encoding="utf-8") as f:
        metadatas = json.load(f)

    # 4) 차원 일치 확인
    embed_dim = model.get_sentence_embedding_dimension()
    assert index.d == embed_dim, f"Index dimension ({index.d}) != Model dimension ({embed_dim})"
    print(f"✅ Index dimension matches model: {embed_dim}")

    # 5) 간단한 검색 테스트
    queries = [
        "금리 인상 여파",
        "기업 실적 발표",
        "미국 주가 전망"
    ]
    k = 3
    for q in queries:
        q_emb = model.encode([q], convert_to_numpy=True)
        D, I = index.search(q_emb, k)
        print(f"\n🔎 Query: {q}")
        for distance, idx in zip(D[0], I[0]):
            meta = metadatas[idx]
            title = meta.get("title", "(제목 없음)")
            source = meta.get("source", "(출처 없음)")
            published = meta.get("publishedAt", "(날짜 없음)")
            print(f"  - {title} | {source} | {published} (distance: {distance:.4f})")

    print("\n🎉 테스트 완료: 모든 검색 및 인덱스 로드가 성공적으로 수행되었습니다.")


if __name__ == "__main__":
    main()

# (venv) PS C:\Users\toast\genai> python src/search/test.py
      
# C:\Users\toast\genai\venv\lib\site-packages\sentence_transformers\SentenceTransformer.py:196: FutureWarning: The `use_auth_token` argument is deprecated and will be removed in v4 of SentenceTransformers.
#   warnings.warn(
# ✅ Index dimension matches model: 384

# 🔎 Query: 금리 인상 여파
#   - quri-parts-ionq 0.22.0 | Pypi.org | 2025-05-12T07:30:58Z (distance: 1.1329)
#   - pulumi-okta 4.19.0a1746771698 | Pypi.org | 2025-05-09T06:30:44Z (distance: 1.1329)
#   - pulumi-okta 4.19.0a1746734672 | Pypi.org | 2025-05-08T20:16:28Z (distance: 1.1329)

# 🔎 Query: 기업 실적 발표
#   - Chimps' rhythmic drumming and complex calls hint at origins of human language | NPR | 2025-05-12T10:00:00Z (distance: 1.2740)
#   - quri-parts-ionq 0.22.0 | Pypi.org | 2025-05-12T07:30:58Z (distance: 1.2801)
#   - pulumi-okta 4.19.0a1746771698 | Pypi.org | 2025-05-09T06:30:44Z (distance: 1.2801)

# 🔎 Query: 미국 주가 전망
#   - quri-parts-ionq 0.22.0 | Pypi.org | 2025-05-12T07:30:58Z (distance: 1.1091)
#   - pulumi-okta 4.19.0a1746771698 | Pypi.org | 2025-05-09T06:30:44Z (distance: 1.1091)
#   - pulumi-okta 4.19.0a1746734672 | Pypi.org | 2025-05-08T20:16:28Z (distance: 1.1091)

# 🎉 테스트 완료: 모든 검색 및 인덱스 로드가 성공적으로 수 행되었습니다.
```
- [V] 정상 동작 확인

