### PR TITLE
feat: GPT fallback 기반 리스크 판단 기능 병합

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv/
 __pycache__/
 *.py[cod]
 .env
+/vectorstore

--- a/data/labeled_news.json
+++ b/data/labeled_news.json
@@ -1,0 +1,1018 @@
+[
+  {
+    "sentiment": "negative",
+    "summary": "NVIDIA recently missed revenue expectations for the quarter, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "missed earnings",
+      "decline"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Hyundai recently missed revenue expectations for the quarter, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Hyundai",
+      "missed earnings",
+      "decline"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Boeing recently launched an innovative product, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "product launch",
+      "innovation"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Netflix recently saw a rise in stock price after a positive analyst rating, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Netflix",
+      "stock rise",
+      "analyst upgrade"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Google recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Google",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Apple recently announced a major strategic partnership, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "partnership",
+      "collaboration"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Amazon recently announced minor changes to its pricing structure, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "pricing",
+      "policy update"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Tesla recently experienced a data breach impacting user information, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "data breach",
+      "cybersecurity"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "NVIDIA recently was involved in a major lawsuit, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "lawsuit",
+      "legal issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Boeing recently hosted its annual developer conference, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "event",
+      "conference"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Boeing recently announced a product recall affecting thousands, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "recall",
+      "safety issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Google recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Google",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Hyundai recently experienced a data breach impacting user information, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Hyundai",
+      "data breach",
+      "cybersecurity"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Amazon recently launched an innovative product, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "product launch",
+      "innovation"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Google recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Google",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Microsoft recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Microsoft",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Google recently missed revenue expectations for the quarter, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Google",
+      "missed earnings",
+      "decline"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Tesla recently launched an innovative product, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "product launch",
+      "innovation"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Tesla recently expanded operations into new global markets, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "expansion",
+      "global market"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Samsung recently shared its long-term roadmap for AI strategy, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Samsung",
+      "roadmap",
+      "AI"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "NVIDIA recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Tesla recently launched an innovative product, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "product launch",
+      "innovation"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Amazon recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Amazon recently reported strong quarterly earnings, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "earnings",
+      "growth",
+      "Q2"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Apple recently was involved in a major lawsuit, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "lawsuit",
+      "legal issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Samsung recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Samsung",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Meta recently experienced a data breach impacting user information, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Meta",
+      "data breach",
+      "cybersecurity"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Apple recently reported strong quarterly earnings, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "earnings",
+      "growth",
+      "Q2"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Hyundai recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Hyundai",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "NVIDIA recently reported strong quarterly earnings, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "earnings",
+      "growth",
+      "Q2"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Boeing recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "NVIDIA recently hosted its annual developer conference, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "event",
+      "conference"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Google recently saw a rise in stock price after a positive analyst rating, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Google",
+      "stock rise",
+      "analyst upgrade"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Netflix recently hosted its annual developer conference, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Netflix",
+      "event",
+      "conference"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Microsoft recently missed revenue expectations for the quarter, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Microsoft",
+      "missed earnings",
+      "decline"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Tesla recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Tesla recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Netflix recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Netflix",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Meta recently announced a major strategic partnership, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Meta",
+      "partnership",
+      "collaboration"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Amazon recently announced minor changes to its pricing structure, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "pricing",
+      "policy update"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Samsung recently hosted its annual developer conference, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Samsung",
+      "event",
+      "conference"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Apple recently shared its long-term roadmap for AI strategy, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "roadmap",
+      "AI"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Apple recently shared its long-term roadmap for AI strategy, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "roadmap",
+      "AI"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "NVIDIA recently announced a major strategic partnership, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "partnership",
+      "collaboration"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Google recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Google",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Boeing recently announced a major strategic partnership, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "partnership",
+      "collaboration"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Boeing recently was involved in a major lawsuit, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "lawsuit",
+      "legal issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Microsoft recently missed revenue expectations for the quarter, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Microsoft",
+      "missed earnings",
+      "decline"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "NVIDIA recently announced minor changes to its pricing structure, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "pricing",
+      "policy update"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Boeing recently announced minor changes to its pricing structure, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "pricing",
+      "policy update"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Apple recently hosted its annual developer conference, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "event",
+      "conference"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Apple recently announced minor changes to its pricing structure, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "pricing",
+      "policy update"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "NVIDIA recently launched an innovative product, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "product launch",
+      "innovation"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Samsung recently saw a rise in stock price after a positive analyst rating, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Samsung",
+      "stock rise",
+      "analyst upgrade"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Apple recently announced a major strategic partnership, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "partnership",
+      "collaboration"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Boeing recently experienced a data breach impacting user information, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "data breach",
+      "cybersecurity"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Hyundai recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Hyundai",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Intel recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Intel",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Apple recently announced minor changes to its pricing structure, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "pricing",
+      "policy update"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Amazon recently launched an innovative product, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "product launch",
+      "innovation"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Amazon recently was involved in a major lawsuit, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "lawsuit",
+      "legal issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Intel recently expanded operations into new global markets, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Intel",
+      "expansion",
+      "global market"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Microsoft recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Microsoft",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Apple recently hosted its annual developer conference, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "event",
+      "conference"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Tesla recently announced minor changes to its pricing structure, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "pricing",
+      "policy update"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Intel recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Intel",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Intel recently was involved in a major lawsuit, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Intel",
+      "lawsuit",
+      "legal issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Apple recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Google recently announced a product recall affecting thousands, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Google",
+      "recall",
+      "safety issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "NVIDIA recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Samsung recently saw a rise in stock price after a positive analyst rating, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Samsung",
+      "stock rise",
+      "analyst upgrade"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Hyundai recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Hyundai",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Hyundai recently reported strong quarterly earnings, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Hyundai",
+      "earnings",
+      "growth",
+      "Q2"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "NVIDIA recently expanded operations into new global markets, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "expansion",
+      "global market"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Boeing recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Intel recently hosted its annual developer conference, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Intel",
+      "event",
+      "conference"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Samsung recently hosted its annual developer conference, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Samsung",
+      "event",
+      "conference"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Meta recently experienced a data breach impacting user information, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Meta",
+      "data breach",
+      "cybersecurity"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Apple recently launched an innovative product, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "product launch",
+      "innovation"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Amazon recently launched an innovative product, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "product launch",
+      "innovation"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Amazon recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "NVIDIA recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Tesla recently was involved in a major lawsuit, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "lawsuit",
+      "legal issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Apple recently announced a product recall affecting thousands, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "recall",
+      "safety issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Boeing recently announced a product recall affecting thousands, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "recall",
+      "safety issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Netflix recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Netflix",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Amazon recently was involved in a major lawsuit, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Amazon",
+      "lawsuit",
+      "legal issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Tesla recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Tesla",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "NVIDIA recently experienced a data breach impacting user information, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "data breach",
+      "cybersecurity"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Microsoft recently missed revenue expectations for the quarter, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Microsoft",
+      "missed earnings",
+      "decline"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Apple recently experienced a data breach impacting user information, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "data breach",
+      "cybersecurity"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Hyundai recently faced regulatory scrutiny and fines, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Hyundai",
+      "regulation",
+      "fine",
+      "scrutiny"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Samsung recently reported strong quarterly earnings, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Samsung",
+      "earnings",
+      "growth",
+      "Q2"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "NVIDIA recently expanded operations into new global markets, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "expansion",
+      "global market"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Netflix recently missed revenue expectations for the quarter, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Netflix",
+      "missed earnings",
+      "decline"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Boeing recently shared its long-term roadmap for AI strategy, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Boeing",
+      "roadmap",
+      "AI"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "positive",
+    "summary": "Apple recently reported strong quarterly earnings, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Apple",
+      "earnings",
+      "growth",
+      "Q2"
+    ],
+    "label": "매수"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "NVIDIA recently hired a new CTO with experience in robotics, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "NVIDIA",
+      "executive hire",
+      "leadership"
+    ],
+    "label": "관망"
+  },
+  {
+    "sentiment": "negative",
+    "summary": "Meta recently was involved in a major lawsuit, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Meta",
+      "lawsuit",
+      "legal issue"
+    ],
+    "label": "매도"
+  },
+  {
+    "sentiment": "neutral",
+    "summary": "Intel recently filed a patent for a new device design, drawing significant attention from industry analysts. This move is expected to impact its performance in the coming quarters. Investors are closely watching how the situation unfolds.",
+    "keywords": [
+      "Intel",
+      "patent",
+      "R&D"
+    ],
+    "label": "관망"
+  }
+]

--- a/src/features/feature_engineering.py
+++ b/src/features/feature_engineering.py
@@ -1,0 +1,20 @@
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer('baconnier/Finance2_embedding_small_en-V1.5')
+
+def build_feature_vector(news_item):
+    """
+    news_item: {
+        "sentiment": "positive",
+        "summary": "Apple exceeded earnings expectations...",
+        "keywords": ["earnings", "iPhone"]
+    }
+    """
+    sentiment_map = {"positive": 1, "neutral": 0, "negative": -1}
+    sentiment_score = sentiment_map.get(news_item["sentiment"], 0)
+
+    summary_vec = model.encode(news_item["summary"])
+    keywords_vec = model.encode(" ".join(news_item["keywords"]))
+
+    return np.concatenate([[sentiment_score], summary_vec, keywords_vec])

--- a/src/llm/llm_fallback.py
+++ b/src/llm/llm_fallback.py
@@ -1,0 +1,24 @@
+import os
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+def gpt_risk_decision(news_item):
+    prompt = f"""
+너는 투자 전문가고, 다음은 기사 요약, 감성 분석, 키워드야.
+요소들을 종합해서 이 뉴스에 대해 '매수', '관망', '매도' 중 하나로 판단해줘.
+
+요약: {news_item['summary']}
+감성 분석 결과: {news_item['sentiment']}
+키워드: {', '.join(news_item['keywords'])}
+
+판단:
+    """
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3
+    )
+    return response.choices[0].message.content.strip()

--- a/src/risk_model/predict_risk.py
+++ b/src/risk_model/predict_risk.py
@@ -1,0 +1,28 @@
+import joblib
+import numpy as np
+from src.features.feature_engineering import build_feature_vector
+from src.llm.llm_fallback import gpt_risk_decision
+
+model = joblib.load("models/risk_model.pkl")
+label_map_rev = {0: "매수", 1: "관망", 2: "매도"}
+
+def predict_with_fallback(news_item, threshold=0.6):
+    feature = build_feature_vector(news_item).reshape(1, -1)
+    proba = model.predict_proba(feature)[0]
+    confidence = max(proba)
+    prediction = model.predict(feature)[0]
+    
+    if confidence < threshold:
+        print(f"🤔 확신 낮음 ({confidence:.2f}) → GPT-4 호출")
+        return gpt_risk_decision(news_item)
+    else:
+        return label_map_rev[prediction]
+
+# 예시
+if __name__ == "__main__":
+    test_news = {
+        "sentiment": "positive",
+        "summary": "Apple exceeded earnings expectations...",
+        "keywords": ["earnings", "iPhone"]
+    }
+    print("최종 판단:", predict_with_fallback(test_news))

--- a/src/risk_model/train_model.py
+++ b/src/risk_model/train_model.py
@@ -1,0 +1,23 @@
+import json
+import joblib
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+from src.features.feature_engineering import build_feature_vector
+
+with open("data/labeled_news.json", "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+X = []
+y = []
+label_map = {"매수": 0, "관망": 1, "매도": 2}
+
+for item in data:
+    feature = build_feature_vector(item)
+    X.append(feature)
+    y.append(label_map[item["label"]])
+
+model = RandomForestClassifier(n_estimators=100, random_state=42)
+model.fit(X, y)
+
+joblib.dump(model, "models/risk_model.pkl")
+print("✅ 모델 학습 및 저장 완료")

--- a/src/search/embed_document.py
+++ b/src/search/embed_document.py
@@ -1,0 +1,58 @@
+#단일 문서 임베딩을 위한 코드
+import os
+import json
+from tqdm import tqdm
+import faiss
+from sentence_transformers import SentenceTransformer
+
+# 1. 금융 특화 SBERT 모델 로딩
+MODEL_NAME = "baconnier/Finance2_embedding_small_en-V1.5"
+model = SentenceTransformer(MODEL_NAME,
+                            use_auth_token=True)
+
+# 2. 데이터 경로 설정
+data_dir = "data/news"
+
+# 3. 문서와 메타데이터 수집
+documents = []
+metadatas = []
+for filename in os.listdir(data_dir):
+    if not filename.endswith(".json"):
+        continue
+    with open(os.path.join(data_dir, filename), "r", encoding="utf-8") as f:
+        articles = json.load(f)
+    for art in articles:
+        txt = art.get("full_content", "").strip()
+        if len(txt) < 30:
+            continue
+        documents.append(txt)
+        metadatas.append({
+            "title": art.get("title"),
+            "source": art.get("source", {}).get("name"),
+            "publishedAt": art.get("publishedAt"),
+            "filename": filename
+        })
+
+print(f"▶ 임베딩할 문서 수: {len(documents)}")
+
+# 4. 배치 임베딩 수행
+# convert_to_numpy=True 로 넘파이 배열 반환, show_progress_bar=True 로 진행 표시
+embeddings = model.encode(
+    documents,
+    batch_size=32,
+    show_progress_bar=True,
+    convert_to_numpy=True
+)
+
+# 5. FAISS 인덱스 생성 및 저장
+dim = embeddings.shape[1]
+index = faiss.IndexFlatL2(dim)
+index.add(embeddings)
+
+os.makedirs("vectorstore", exist_ok=True)
+faiss.write_index(index, "vectorstore/financial_news_index.faiss")
+
+with open("vectorstore/financial_news_metadata.json", "w", encoding="utf-8") as f:
+    json.dump(metadatas, f, ensure_ascii=False, indent=2)
+
+print("✅ 금융 특화 FAISS 인덱스 및 메타데이터 저장 완료")

--- a/src/search/index_news.py
+++ b/src/search/index_news.py
@@ -1,0 +1,82 @@
+#뉴스 코퍼스 전체를 한 번에 읽어서 임베딩하고 FAISS 인덱스를 생성해 파일로 저장하는 배치 스크립트트
+
+import os
+import json
+import faiss
+from sentence_transformers import SentenceTransformer
+
+
+def main():
+    # 1) 금융 특화 SBERT 모델 로드
+    MODEL_NAME = "baconnier/Finance2_embedding_small_en-V1.5"
+    model = SentenceTransformer(MODEL_NAME)
+
+    # 2) 프로젝트 루트 기준 뉴스 데이터 경로
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    data_dir = os.path.join(project_root, "data", "news")
+
+    if not os.path.isdir(data_dir):
+        raise FileNotFoundError(f"뉴스 데이터 디렉토리를 찾을 수 없습니다: {data_dir}")
+
+    # 3) 뉴스 문서와 메타데이터 수집
+    documents = []
+    metadatas = []
+    for fn in os.listdir(data_dir):
+        if not fn.endswith(".json"): 
+            continue
+        path = os.path.join(data_dir, fn)
+        with open(path, "r", encoding="utf-8") as f:
+            articles = json.load(f)
+        for art in articles:
+            raw = art.get("full_content")
+            if not raw:
+                continue
+            text = raw.strip()
+            if len(text) < 30:
+                continue
+            documents.append(text)
+            metadatas.append({
+                "title": art.get("title"),
+                "source": art.get("source", {}).get("name"),
+                "publishedAt": art.get("publishedAt"),
+                "filename": fn
+            })
+
+    print(f"▶ 임베딩 문서 수: {len(documents)}")
+
+    # 4) 배치 임베딩 수행
+    embeddings = model.encode(
+        documents,
+        batch_size=32,
+        show_progress_bar=True,
+        convert_to_numpy=True
+    )
+
+    # 5) FAISS 인덱스 생성
+    dim = embeddings.shape[1]
+    index = faiss.IndexFlatL2(dim)
+    index.add(embeddings)
+
+    # 6) 인덱스 및 메타데이터 저장 경로
+    vs_dir = os.path.join(project_root, "vectorstore")
+    os.makedirs(vs_dir, exist_ok=True)
+    index_path = os.path.join(vs_dir, "financial_news_index.faiss")
+    meta_path = os.path.join(vs_dir, "financial_news_metadata.json")
+
+    # 7) 파일로 저장
+    faiss.write_index(index, index_path)
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(metadatas, f, ensure_ascii=False, indent=2)
+
+    print(f"✅ FAISS 인덱스 저장 완료: {index_path}")
+
+
+if __name__ == "__main__":
+    main()
+
+# (venv) PS C:\Users\toast\genai> python src/search/index_news.py
+# C:\Users\toast\genai\venv\lib\site-packages\sentence_transformers\SentenceTransformer.py:196: FutureWarning: The `use_auth_token` argument is deprecated and will be removed in v4 of SentenceTransformers.
+#   warnings.warn(
+# ▶ 임베딩 문서 수: 332
+# Batches: 100%|██████████| 11/11 [01:40<00:00,  9.18s/it]
+# ✅ FAISS 인덱스 저장 완료: C:\Users\toast\genai\vectorstore\financial_news_index.faiss

--- a/src/search/test.py
+++ b/src/search/test.py
@@ -1,0 +1,77 @@
+import os
+import json
+import faiss
+from sentence_transformers import SentenceTransformer
+
+
+def main():
+    # 1) 모델 로드
+    MODEL_NAME = "baconnier/Finance2_embedding_small_en-V1.5"
+    model = SentenceTransformer(MODEL_NAME)
+
+    # 2) FAISS 인덱스 로드 
+    index_path = os.path.join("vectorstore", "financial_news_index.faiss")
+    metadata_path = os.path.join("vectorstore", "financial_news_metadata.json")
+
+    assert os.path.exists(index_path), f"Index file not found: {index_path}"
+    assert os.path.exists(metadata_path), f"Metadata file not found: {metadata_path}"
+
+    index = faiss.read_index(index_path)
+
+    # 3) 메타데이터 로드
+    with open(metadata_path, "r", encoding="utf-8") as f:
+        metadatas = json.load(f)
+
+    # 4) 차원 일치 확인
+    embed_dim = model.get_sentence_embedding_dimension()
+    assert index.d == embed_dim, f"Index dimension ({index.d}) != Model dimension ({embed_dim})"
+    print(f"✅ Index dimension matches model: {embed_dim}")
+
+    # 5) 간단한 검색 테스트
+    queries = [
+        "금리 인상 여파",
+        "기업 실적 발표",
+        "미국 주가 전망"
+    ]
+    k = 3
+    for q in queries:
+        q_emb = model.encode([q], convert_to_numpy=True)
+        D, I = index.search(q_emb, k)
+        print(f"\n🔎 Query: {q}")
+        for distance, idx in zip(D[0], I[0]):
+            meta = metadatas[idx]
+            title = meta.get("title", "(제목 없음)")
+            source = meta.get("source", "(출처 없음)")
+            published = meta.get("publishedAt", "(날짜 없음)")
+            print(f"  - {title} | {source} | {published} (distance: {distance:.4f})")
+
+    print("\n🎉 테스트 완료: 모든 검색 및 인덱스 로드가 성공적으로 수행되었습니다.")
+
+
+if __name__ == "__main__":
+    main()
+
+# 실행 예시:
+# (venv) PS C:\Users\toast\genai> python src/search/test.py
+      
+# C:\Users\toast\genai\venv\lib\site-packages\sentence_transformers\SentenceTransformer.py:196: FutureWarning: The `use_auth_token` argument is deprecated and will be removed in v4 of SentenceTransformers.
+#   warnings.warn(
+# ✅ Index dimension matches model: 384
+
+# 🔎 Query: 금리 인상 여파
+#   - quri-parts-ionq 0.22.0 | Pypi.org | 2025-05-12T07:30:58Z (distance: 1.1329)
+#   - pulumi-okta 4.19.0a1746771698 | Pypi.org | 2025-05-09T06:30:44Z (distance: 1.1329)
+#   - pulumi-okta 4.19.0a1746734672 | Pypi.org | 2025-05-08T20:16:28Z (distance: 1.1329)
+
+# 🔎 Query: 기업 실적 발표
+#   - Chimps' rhythmic drumming and complex calls hint at origins of human language | NPR | 2025-05-12T10:00:00Z (distance: 1.2740)
+#   - quri-parts-ionq 0.22.0 | Pypi.org | 2025-05-12T07:30:58Z (distance: 1.2801)
+#   - pulumi-okta 4.19.0a1746771698 | Pypi.org | 2025-05-09T06:30:44Z (distance: 1.2801)
+
+# 🔎 Query: 미국 주가 전망
+#   - quri-parts-ionq 0.22.0 | Pypi.org | 2025-05-12T07:30:58Z (distance: 1.1091)
+#   - pulumi-okta 4.19.0a1746771698 | Pypi.org | 2025-05-09T06:30:44Z (distance: 1.1091)
+#   - pulumi-okta 4.19.0a1746734672 | Pypi.org | 2025-05-08T20:16:28Z (distance: 1.1091)
+
+# 🎉 테스트 완료: 모든 검색 및 인덱스 로드가 성공적으로 수행되었습니다.
+# (venv) PS C:\Users\toast\genai> 


### PR DESCRIPTION
## 📌 개요
- 리스크 판단 시 모델 confidence가 낮은 경우, GPT-4를 활용해 보완 판단 수행
- 기존 규칙 기반 또는 ML 기반 판단의 한계를 보완하고, 유연한 의사결정 체계를 확보하기 위함

## ✨ 주요 변경 사항
- [x] `llm_fallback.py`: GPT-4 기반 판단 로직 구현 (OpenAI SDK v1 적용)
- [x] `predict_risk.py`: 모델 예측 결과가 불확실할 경우 fallback 호출 연동
- [x] 예시 데이터에 대해 예측 후 GPT로 판단 요청 흐름 구현

## 🧪 테스트
- [x] 실행 명령어: `python src/risk_model/predict_risk.py`
- [x] 예상 결과: `최종 판단: 매수 / 보류 / 매도` 형태의 출력 확인
- [x] 정상 동작 확인함: 예

## 📝 기타 참고사항
- [ ] 향후 개선 방향:
  - GPT 판단 결과에 대한 사후 정량적 평가
  - News + 공시자료 통합 판단으로 확장 예정